### PR TITLE
Added function to set no data values to -99.0

### DIFF
--- a/noise_raster/noise_raster.py
+++ b/noise_raster/noise_raster.py
@@ -31,7 +31,7 @@ from os.path import isfile, join
 import numpy as np
 import sys
 
-from .raster_processing import sum_sound_level_3D, merge_rasters, vectorize, check_projection, validate_source_format, check_extent, create_raster, build_virtual_raster, reproject, source_raster_list, create_zero_array
+from .raster_processing import sum_sound_level_3D, merge_rasters, vectorize, check_projection, validate_source_format, check_extent, create_raster, build_virtual_raster, reproject, source_raster_list, create_zero_array, set_nodata_value
 
 # Initialize Qt resources from file resources.py
 from .resources import *
@@ -291,12 +291,15 @@ class NoiseRaster:
                 out_ras = self.dlg.mQgsFileWidget_outRas.filePath()
                 out_energetic_ras =create_raster(data_out, out_ras, mergedVRT)
 
+                # Set no data value to -99.0
+                out_final_ras = set_nodata_value(out_energetic_ras)
+
                 # Get reclassification table
                 selectedTableIndex = self.dlg.comboBox.currentIndex()
 
                 # Vectorize energetically added raster including all noise sources
                 out_poly = self.dlg.mQgsFileWidget_outShp.filePath()
-                vectorize(out_energetic_ras, out_poly, selectedTableIndex)
+                vectorize(out_final_ras, out_poly, selectedTableIndex)
 
             else:
 

--- a/noise_raster/raster_processing.py
+++ b/noise_raster/raster_processing.py
@@ -118,7 +118,7 @@ def build_virtual_raster(in_vrt:list):
 
 def create_zero_array(in_ds):
     """
-    Create masked array as input to energetic addition. Masked arrays handle no data values.
+    Create array as input to energetic addition.
     """
     # Open dataset
     ds = gdal.Open(in_ds)
@@ -130,7 +130,7 @@ def create_zero_array(in_ds):
 
     return zeroData
 
-def create_raster(sound_array, out_pth, merged_vrt):
+def create_raster(sound_array:np.ndarray, out_pth, merged_vrt):
     """
     Create raster based on energetically added array
     """
@@ -376,3 +376,23 @@ def validate_source_format(srcData:list):
         out_ras.append(out_tif)
 
     return out_ras
+
+def set_nodata_value(in_ds):
+    """
+    Check the existing no data value of raster.
+    Set no data value to -99.0
+    """
+
+    # Read existing no data value(s)
+    dst_ds = gdal.Open(in_ds, gdal.GA_Update)
+    ndv = dst_ds.GetRasterBand(1).GetNoDataValue()
+    newndv = -99.0
+    band1 = dst_ds.GetRasterBand(1).ReadAsArray()
+    band1[band1 == ndv] = newndv
+
+    # Set no data value for source rasters to -99.0
+    dst_ds.GetRasterBand(1).SetNoDataValue(newndv)
+    dst_ds.GetRasterBand(1).WriteArray(band1)
+    dst_ds = None
+
+    return in_ds


### PR DESCRIPTION
All negative values are set to 0 as input to the energetic addition. This function sets the no data value of the output raster to -99.0.